### PR TITLE
Add SignIn items to tree

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -2,8 +2,10 @@
     "playfab-account.description": "A common PlayFab Sign-In extension for VS Code.",
     "playfab-account.commands.playfab": "PlayFab Account",
     "playfab-account.commands.login": "Sign In",
+    "playfab-account.commands.loginTitle": "Sign In to PlayFab...",
     "playfab-account.commands.logout": "Sign Out",
     "playfab-account.commands.createAccount": "Create an account",
+    "playfab-account.commands.createAccountTitle": "Create a PlayFab account...",
     "playfab-account.loggingin": "PlayFab: Signing in...",
     "playfab-account.loggedin": "PlayFab: {0}",
     "playfab-account.cancel": "Cancel",
@@ -25,6 +27,8 @@
     "playfab-explorer.commands.setTitleInternalData": "Set title internal data",
     "playfab-explorer.commands.getCloudScriptRevision": "Get CloudScript revision",
     "playfab-explorer.commands.updateCloudScript": "Update CloudScript",
+    "playfab-explorer.commands.createFunctionApp": "Create Function App",
+    "playfab-explorer.commands.addFunction": "Add Function",
     "playfab-explorer.commands.openGameManagerPageForTitle": "Open in Game Manager",
     "playfab-explorer.cloudscriptUpdated": "CloudScript updated to revision {0}.",
     "playfab-explorer.noTitleData": "No title data found with specified key(s).",
@@ -38,6 +42,5 @@
     "playfab-explorer.keyValue": "Key Name",
     "playfab-explorer.keyPrompt": "Please enter the key name.",
     "playfab-explorer.valueValue": "Value",
-    "playfab-explorer.valuePrompt": "Please enter the value.",
-    "playfab-explorer.pleaseLogin": "Please log in to your PlayFab account."
+    "playfab-explorer.valuePrompt": "Please enter the value."
 }

--- a/src/playfab-account.ts
+++ b/src/playfab-account.ts
@@ -226,7 +226,7 @@ export class PlayFabLoginManager {
     }
 
     private updateStatus(status: PlayFabLoginStatus): void {
-        if (this.api.status != status) {
+        if (this.api.status !== status) {
             (<PlayFabAccountWritable>this.api).status = status;
             this.onStatusChanged.fire(this.api.status);
         }


### PR DESCRIPTION
Update the PlayFabStudioTreeViewProvider to return SignIn and
CreateAccount tree view items in the case where the user is not
logged in.

Details

Amend getChildren to check for sign-in state in the case of a null or
undefined entry. Such cases mean we are being asked for the
'root nodes'. If the user is signed in, we return the Studio nodes as
before. If the user is not signed in, we return two 'Command' items; one
for sign-in and one for account creation.

Add localizable strings for the command titles.

Add an await to the HTTP API call in updateStudioData and propogate the
Promise signature appropriately.

Remove the code in updateStudioData that displayed a popup message if
the user was not signed in.

Add an isLoggedIn method and use where appropriate.

Some cleanup of != => !==