### PR TITLE
Make HTTP Client Mockable

### DIFF
--- a/src/helpers/PlayFabHttpHelper.ts
+++ b/src/helpers/PlayFabHttpHelper.ts
@@ -4,16 +4,26 @@
 //---------------------------------------------------------------------------------------------
 
 import * as http from 'typed-rest-client/HttpClient';
-import { PlayFabAccount } from '../playfab-account.api';
 import { ExtensionInfo } from '../extension';
 
-export class PlayFabHttpClient {
+export interface IHttpClient {
+    makeApiCall<TRequest, TResponse>(
+        path: string,
+        endpoint: string,
+        request: TRequest,
+        responseCallback: (response: TResponse) => void,
+        errorCallback: (code: number, error: string) => void): Promise<void>;
 
-    private _account: PlayFabAccount;
+    makeTitleApiCall<TRequest, TResponse>(
+            path: string,
+            endpoint: string,
+            request: TRequest,
+            titleSecret: string,
+            responseCallback: (response: TResponse) => void,
+            errorCallback: (code: number, error: string) => void): Promise<void>;
+}
 
-    constructor(account: PlayFabAccount) {
-        this._account = account;
-    }
+export class PlayFabHttpClient implements IHttpClient {
 
     public async makeApiCall<TRequest, TResponse>(
         path: string,


### PR DESCRIPTION
Add an IHttpClient interface and amend PlayFabHttpHelper to implement
it.

Amend PlayFabLoginManager, PlayFabExplorer and PlayFabStudioTreeProvider
to take an optional IHttpClient parameter in their constructors. If one
is not provided, just create a PlayFabHttpHelper. This will allow us to
pass in a mock IHttpClient for testing purposes.

Amend all HTTP call sites to use the private field rather than consing
up one in each function.