### PR TITLE
Add tests for RegisterAccount

### DIFF
--- a/src/playfab-account.ts
+++ b/src/playfab-account.ts
@@ -18,6 +18,7 @@ interface PlayFabAccountWritable extends PlayFabAccount {
 }
 
 export interface IPlayFabLoginInputGatherer {
+    getUserInputForCreateAccount(): Promise<CreateAccountRequest>;
     getUserInputForLogin(): Promise<LoginRequest>;    
 }
 
@@ -153,49 +154,7 @@ export class PlayFabLoginManager {
     }
 
     private async getUserInputForCreateAccount(): Promise<CreateAccountRequest> {
-        const emailPrompt: string = localize('playfab-account.emailPrompt', 'Please enter your e-mail address');
-        const emailAddress: string = await window.showInputBox({
-            value: 'user@company.com',
-            prompt: emailPrompt
-        });
-
-        const newPasswordPrompt: string = localize('playfab-account.newPasswordPrompt', 'Please enter a password. Your password must be 8 characters or longer and contain at least two of these: uppercase characters, numbers, or symbols.');
-        const password: string = await window.showInputBox({
-            value: '',
-            prompt: newPasswordPrompt,
-            password: true
-        });
-
-        const reenterPasswordPrompt: string = localize('playfab-account.reenterPasswordPrompt', 'Please re-enter the password.');
-        const secondpassword: string = await window.showInputBox({
-            value: '',
-            prompt: reenterPasswordPrompt,
-            password: true
-        });
-
-        const studioNamePrompt: string = localize('playfab-account.studioNamePrompt', 'Please enter the name of your game studio.');
-        const studioName: string = await window.showInputBox({
-            value: '',
-            prompt: studioNamePrompt
-        });
-
-        let result: CreateAccountRequest = null;
-
-        if (password === secondpassword) {
-            result = new CreateAccountRequest();
-
-            result.Email = emailAddress;
-            result.Password = password;
-            result.StudioName = studioName;
-            result.DeveloperToolProductName = ExtensionInfo.getExtensionName();
-            result.DeveloperToolProductVersion = ExtensionInfo.getExtensionVersion();
-        }
-        else {
-            const msg: string = localize('playfab-account.passwordMismatch', 'Passwords did not match.');
-            await window.showErrorMessage(msg);
-        }
-
-        return result;
+        return await this._inputGatherer.getUserInputForCreateAccount();
     }
 
     private async getUserInputForLogin(): Promise<LoginRequest> {
@@ -246,6 +205,52 @@ export class PlayFabLoginManager {
 }
 
 class PlayFabLoginUserInputGatherer implements IPlayFabLoginInputGatherer {
+    public async getUserInputForCreateAccount(): Promise<CreateAccountRequest> {
+        const emailPrompt: string = localize('playfab-account.emailPrompt', 'Please enter your e-mail address');
+        const emailAddress: string = await window.showInputBox({
+            value: 'user@company.com',
+            prompt: emailPrompt
+        });
+
+        const newPasswordPrompt: string = localize('playfab-account.newPasswordPrompt', 'Please enter a password. Your password must be 8 characters or longer and contain at least two of these: uppercase characters, numbers, or symbols.');
+        const password: string = await window.showInputBox({
+            value: '',
+            prompt: newPasswordPrompt,
+            password: true
+        });
+
+        const reenterPasswordPrompt: string = localize('playfab-account.reenterPasswordPrompt', 'Please re-enter the password.');
+        const secondpassword: string = await window.showInputBox({
+            value: '',
+            prompt: reenterPasswordPrompt,
+            password: true
+        });
+
+        const studioNamePrompt: string = localize('playfab-account.studioNamePrompt', 'Please enter the name of your game studio.');
+        const studioName: string = await window.showInputBox({
+            value: '',
+            prompt: studioNamePrompt
+        });
+
+        let result: CreateAccountRequest = null;
+
+        if (password === secondpassword) {
+            result = new CreateAccountRequest();
+
+            result.Email = emailAddress;
+            result.Password = password;
+            result.StudioName = studioName;
+            result.DeveloperToolProductName = ExtensionInfo.getExtensionName();
+            result.DeveloperToolProductVersion = ExtensionInfo.getExtensionVersion();
+        }
+        else {
+            const msg: string = localize('playfab-account.passwordMismatch', 'Passwords did not match.');
+            await window.showErrorMessage(msg);
+        }
+
+        return result;
+    }
+
     public async getUserInputForLogin(): Promise<LoginRequest> {
         const emailPrompt: string = localize('playfab-account.emailPrompt', 'Please enter your e-mail address');
         const emailAddress: string = await window.showInputBox({

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -9,31 +9,73 @@ import * as Moq from 'typemoq'
 import { IHttpClient } from '../helpers/PlayFabHttpHelper'
 import { CreateAccountRequest, CreateAccountResponse, LoginResponse, LoginRequest, LogoutRequest, LogoutResponse } from '../models/PlayFabAccountModels';
 import { PlayFabLoginManager, IPlayFabLoginInputGatherer } from '../playfab-account';
+import { beforeEach } from 'mocha';
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 // import * as vscode from 'vscode';
 // import * as myExtension from '../extension';
 
-
 // Defines a Mocha test suite to group tests of similar kind together
 suite('Extension Tests', function () {
 
+  class User {
+    email: string;
+    password: string;
+    twofa: string;
+    studioName: string;
+    devToolName: string;
+    devToolVersion: string;
+    token: string;
+  }
+
+  let user1: User = {
+    email: "user1@domain.suffix",
+    password: "supersecret",
+    twofa:  "123456",
+    studioName:  "Small And Fast",
+    devToolName:  "UnitTest",
+    devToolVersion:  "001",
+    token: "abcdef"
+  };
+
+  let user2: User = {
+    email: "user2@domain.suffix",
+    password: "SuperSecret",
+    twofa: "456789",
+    studioName: "Big And Slow",
+    devToolName: "UnitTest",
+    devToolVersion: "001",
+    token: "ghi123",
+  };
+
+  let user: User;
   let inputGatherer: Moq.IMock<IPlayFabLoginInputGatherer> = Moq.Mock.ofType<IPlayFabLoginInputGatherer>();
+  inputGatherer.setup(x => x.getUserInputForCreateAccount())
+    .returns(async () => {
+      let result: CreateAccountRequest = {
+        Email: user.email,
+        Password: user.password,
+        StudioName: user.studioName,
+        DeveloperToolProductName: user.devToolName,
+        DeveloperToolProductVersion: user.devToolVersion
+      };
+      return result;
+    });
   inputGatherer.setup(x => x.getUserInputForLogin())
     .returns(async () => {
       let result: LoginRequest = {
-        Email: "user@domain.suffix",
-        Password: "supersecretpassword",
-        TwoFactorAuth: "123456",
-        DeveloperToolProductName: "UnitTest",
-        DeveloperToolProductVersion: "001"
+        Email: user.email,
+        Password: user.password,
+        TwoFactorAuth: user.twofa,
+        DeveloperToolProductName: user.devToolName,
+        DeveloperToolProductVersion: user.devToolVersion
       };
       return result;
-    })
+    });
+
 
   let httpCli: Moq.IMock<IHttpClient> = Moq.Mock.ofType<IHttpClient>();
-  let token: string = "abcdefghihjk";
   httpCli.setup(x => x.makeApiCall(
     Moq.It.isValue('/DeveloperTools/User/Login'),
     Moq.It.isAnyString(),
@@ -48,7 +90,7 @@ suite('Extension Tests', function () {
         errorCallback: (code: number, message: string) => void
       ): Promise<void> => {
         let response: LoginResponse = {
-          DeveloperClientToken: token,
+          DeveloperClientToken: user.token,
         };
         successCallback(response);
         return;
@@ -73,31 +115,99 @@ suite('Extension Tests', function () {
         return;
       });
 
+  httpCli.setup(x => x.makeApiCall(
+    Moq.It.isValue('/DeveloperTools/User/RegisterAccount'),
+    Moq.It.isAnyString(),
+    Moq.It.is<CreateAccountRequest>(x => true),
+    Moq.It.isAny(),
+    Moq.It.isAny()))
+    .returns(
+      (path: string,
+        endpoint: string,
+        request: CreateAccountRequest,
+        successCallback: (response: CreateAccountResponse) => void,
+        errorCallback: (code: number, message: string) => void
+      ): Promise<void> => {
+        let response: CreateAccountResponse = {
+          DeveloperClientToken: user.token
+        };
+        successCallback(response);
+        return;
+      });
+
   // Defines a Mocha unit test
-  test('LoginWhenLoggedOut', async function () {
+  test('CreateAccountWhenLoggedOut', async function () {
+    user = user1;
     let loginManager: PlayFabLoginManager = new PlayFabLoginManager(null, httpCli.object, inputGatherer.object);
     assert(loginManager.api.status === "Initializing", "Status is not Initializing");
-    await loginManager.login()
+    await loginManager.createAccount()
     assert(loginManager.api.status === "LoggedIn", "Status is not LoggedIn");
     let apiToken: string = loginManager.api.getToken();
-    assert(apiToken === token, "Token does not match");
+    assert(apiToken === user1.token, "Token does not match");
   });
 
-  test('LoginWhenLoggedIn', async function () {
+  test('CreateAccountDifferentUserWhenLoggedIn', async function () {
+    user = user1;
     let loginManager: PlayFabLoginManager = new PlayFabLoginManager(null, httpCli.object, inputGatherer.object);
     assert(loginManager.api.status === "Initializing", "Status is not Initializing");
     await loginManager.login()
     assert(loginManager.api.status === "LoggedIn", "Status is not LoggedIn");
     let apiToken: string = loginManager.api.getToken();
-    assert(apiToken === token, "Token does not match");
+    assert(apiToken === user1.token, "Token does not match");
+
+    user = user2;
+
+    await loginManager.createAccount()
+    assert(loginManager.api.status === "LoggedIn", "Status is not LoggedIn");
+    apiToken = loginManager.api.getToken();
+    assert(apiToken === user2.token, "Token does not match");
+  });
+  
+  test('LoginWhenLoggedOut', async function () {
+    user = user1;
+    let loginManager: PlayFabLoginManager = new PlayFabLoginManager(null, httpCli.object, inputGatherer.object);
+    assert(loginManager.api.status === "Initializing", "Status is not Initializing");
+    await loginManager.login()
+
+    assert(loginManager.api.status === "LoggedIn", "Status is not LoggedIn");
+    let apiToken: string = loginManager.api.getToken();
+    assert(apiToken === user1.token, "Token does not match");
+  });
+
+  test('LoginSameUserWhenLoggedIn', async function () {
+    user = user1;
+    let loginManager: PlayFabLoginManager = new PlayFabLoginManager(null, httpCli.object, inputGatherer.object);
+    assert(loginManager.api.status === "Initializing", "Status is not Initializing");
+    await loginManager.login()
+    assert(loginManager.api.status === "LoggedIn", "Status is not LoggedIn");
+    let apiToken: string = loginManager.api.getToken();
+    assert(apiToken === user1.token, "Token does not match");
 
     await loginManager.login()
     assert(loginManager.api.status === "LoggedIn", "Status is not LoggedIn");
     apiToken = loginManager.api.getToken();
-    assert(apiToken === token, "Token does not match");
+    assert(apiToken === user1.token, "Token does not match");
+  });
+
+  test('LoginDifferentUserWhenLoggedIn', async function () {
+    user = user1;
+    let loginManager: PlayFabLoginManager = new PlayFabLoginManager(null, httpCli.object, inputGatherer.object);
+    assert(loginManager.api.status === "Initializing", "Status is not Initializing");
+    await loginManager.login()
+    assert(loginManager.api.status === "LoggedIn", "Status is not LoggedIn");
+    let apiToken: string = loginManager.api.getToken();
+    assert(apiToken === user1.token, "Token does not match");
+
+    user = user2;
+    
+    await loginManager.login()
+    assert(loginManager.api.status === "LoggedIn", "Status is not LoggedIn");
+    apiToken = loginManager.api.getToken();
+    assert(apiToken === user2.token, "Token does not match");
   });
 
   test('LogoutWhenLoggedIn', async function () {
+    user = user1;
     let loginManager: PlayFabLoginManager = new PlayFabLoginManager(null, httpCli.object, inputGatherer.object);
     await loginManager.login()
     assert(loginManager.api.status === "LoggedIn", "Status is not LoggedIn");
@@ -106,6 +216,7 @@ suite('Extension Tests', function () {
   });
 
   test('LogoutWhenLoggedOut', async function () {
+    user = user1;
     let loginManager: PlayFabLoginManager = new PlayFabLoginManager(null, httpCli.object, inputGatherer.object);
     await loginManager.login()
     assert(loginManager.api.status === "LoggedIn", "Status is not LoggedIn");


### PR DESCRIPTION
Also refactor how user related info is set and used to go via a
User object that is set by each test as needed.

Refactor user input gathering for RegisterAccount into the input
gatherer.