### PR TITLE
Better 2FA login flow

### DIFF
--- a/src/models/PlayFabHttpModels.ts
+++ b/src/models/PlayFabHttpModels.ts
@@ -1,0 +1,12 @@
+//---------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License. See License.md in the project root for license information.
+//---------------------------------------------------------------------------------------------
+
+export class ErrorResponse {
+    code: number;
+    status: string;
+    error: string;
+    errorCode: number;
+    errorMessage: string;    
+};

--- a/src/playfab-explorer.ts
+++ b/src/playfab-explorer.ts
@@ -16,6 +16,7 @@ import {
     CloudScriptFile, GetCloudScriptRevisionRequest, GetCloudScriptRevisionResponse,
     UpdateCloudScriptRequest, UpdateCloudScriptResponse
 } from './models/PlayFabLegacyCloudScriptModels';
+import { ErrorResponse } from "./models/PlayFabHttpModels";
 import { Studio, GetStudiosRequest, GetStudiosResponse } from './models/PlayFabStudioModels';
 import {
     Title, CreateTitleRequest, CreateTitleResponse, GetTitleDataRequest, GetTitleDataResponse,
@@ -77,8 +78,8 @@ export class PlayFabExplorer {
             (response: CreateTitleResponse) => {
                 // NOOP
             },
-            (code: number, error: string) => {
-                this.showError(code, error);
+            (response: ErrorResponse) => {
+                this.showError(response);
             });
     }
 
@@ -104,8 +105,8 @@ export class PlayFabExplorer {
                         });
                 }
             },
-            (code: number, error: string) => {
-                this.showError(code, error);
+            (response: ErrorResponse) => {
+                this.showError(response);
             });
     }
 
@@ -128,8 +129,8 @@ export class PlayFabExplorer {
                 const msg: string = localize('playfab-explorer.cloudscriptUpdated', 'CloudScript updated to revision {0}', response.Revision);
                 window.showInformationMessage(msg)
             },
-            (code: number, error: string) => {
-                this.showError(code, error);
+            (response: ErrorResponse) => {
+                this.showError(response);
             });
     }
 
@@ -155,8 +156,8 @@ export class PlayFabExplorer {
                     window.showInformationMessage(msg);
                 }
             },
-            (code: number, error: string) => {
-                this.showError(code, error);
+            (response: ErrorResponse) => {
+                this.showError(response);
             });
     }
 
@@ -174,8 +175,8 @@ export class PlayFabExplorer {
                 const msg: string = localize('playfab-explorer.titleDataSet', 'Title data set');
                 window.showInformationMessage(msg);
             },
-            (code: number, error: string) => {
-                this.showError(code, error);
+            (response: ErrorResponse) => {
+                this.showError(response);
             });
     }
 
@@ -208,8 +209,8 @@ export class PlayFabExplorer {
         return await this._inputGatherer.getUserInputForSetTitleData();
     }
 
-    private showError(statusCode: number, message: string): void {
-        window.showErrorMessage(`${statusCode} - ${message}`);
+    private showError(response: ErrorResponse): void {
+        window.showErrorMessage(`${response.error} - ${response.errorMessage}`);
     }
 }
 
@@ -421,8 +422,8 @@ export class PlayFabStudioTreeProvider implements TreeDataProvider<IEntry> {
             (response: GetStudiosResponse) => {
                 this._rootData = response.Studios;
             },
-            (code: number, error: string) => {
-                this.showError(code, error);
+            (response: ErrorResponse) => {
+                this.showError(response);
                 this.clearRootData();
             });
     }
@@ -448,7 +449,7 @@ export class PlayFabStudioTreeProvider implements TreeDataProvider<IEntry> {
         this._onDidChangeTreeData.fire();
     }
 
-    private showError(statusCode: number, message: string): void {
-        window.showErrorMessage(`${statusCode} - ${message}`);
+    private showError(response: ErrorResponse): void {
+        window.showErrorMessage(`${response.error} - ${response.errorMessage}`);
     }
 }

--- a/src/test/explorer.test.ts
+++ b/src/test/explorer.test.ts
@@ -18,7 +18,9 @@ import {
   GetCloudScriptRevisionRequest, GetCloudScriptRevisionResponse, UpdateCloudScriptRequest,
   UpdateCloudScriptResponse
 } from '../models/PlayFabLegacyCloudScriptModels'
+import { ErrorResponse } from '../models/PlayFabHttpModels';
 import { Studio } from '../models/PlayFabStudioModels';
+
 
 suite('Explorer Tests', function () {
 
@@ -93,7 +95,7 @@ suite('Explorer Tests', function () {
         endpoint: string,
         request: CreateTitleRequest,
         successCallback: (response: CreateTitleResponse) => void,
-        errorCallback: (code: number, message: string) => void
+        errorCallback: (response: ErrorResponse) => void
       ): Promise<void> => {
         createTitleHttpCount++;
         let response: CreateTitleResponse = {
@@ -117,7 +119,7 @@ suite('Explorer Tests', function () {
         request: GetCloudScriptRevisionRequest,
         key: string,
         successCallback: (response: GetCloudScriptRevisionResponse) => void,
-        errorCallback: (code: number, message: string) => void
+        errorCallback: (response: ErrorResponse) => void
       ): Promise<void> => {
         getCloudScriptRevisionHttpCount++;
         let response: GetCloudScriptRevisionResponse = {
@@ -145,7 +147,7 @@ suite('Explorer Tests', function () {
         request: UpdateCloudScriptRequest,
         key: string,
         successCallback: (response: UpdateCloudScriptResponse) => void,
-        errorCallback: (code: number, message: string) => void
+        errorCallback: (response: ErrorResponse) => void
       ): Promise<void> => {
         updateCloudScriptHttpCount++;
         let response: UpdateCloudScriptResponse = {
@@ -170,7 +172,7 @@ suite('Explorer Tests', function () {
         request: GetTitleDataRequest,
         key: string,
         successCallback: (response: GetTitleDataResponse) => void,
-        errorCallback: (code: number, message: string) => void
+        errorCallback: (response: ErrorResponse) => void
       ): Promise<void> => {
         getTitleDataHttpCount++;
         let response: GetTitleDataResponse = {
@@ -194,7 +196,7 @@ suite('Explorer Tests', function () {
         request: GetTitleDataRequest,
         key: string,
         successCallback: (response: GetTitleDataResponse) => void,
-        errorCallback: (code: number, message: string) => void
+        errorCallback: (response: ErrorResponse) => void
       ): Promise<void> => {
         getTitleInternalDataHttpCount++;
         let response: GetTitleDataResponse = {
@@ -218,7 +220,7 @@ suite('Explorer Tests', function () {
         request: SetTitleDataRequest,
         key: string,
         successCallback: (response: SetTitleDataResponse) => void,
-        errorCallback: (code: number, message: string) => void
+        errorCallback: (response: ErrorResponse) => void
       ): Promise<void> => {
         setTitleDataHttpCount++;
         let response: SetTitleDataResponse = {
@@ -241,7 +243,7 @@ suite('Explorer Tests', function () {
         request: SetTitleDataRequest,
         key: string,
         successCallback: (response: SetTitleDataResponse) => void,
-        errorCallback: (code: number, message: string) => void
+        errorCallback: (response: ErrorResponse) => void
       ): Promise<void> => {
         setTitleInternalDataHttpCount++;
         let response: SetTitleDataResponse = {


### PR DESCRIPTION
This PR changes the login flow to only ask for a 2FA code if the account
actually requires it.

Details

Add a getUserInputForTwoFA method to IPlayFabLoginInputGatherer

In the login flow, first ask for username/password, then make the login
call. Iff it fails with error 1246, ask for TwoFA code and make login
call again.

Coin an ErrorResponse type for use in errorcallback when making HTTP API
calls. Amend various callsites and implementations of errorcallback
accordingly.

Amend various showError methods to also take ErrorResponse.

Update various mocks to new HTTP API signature.

Add test for logging in with an account that requires TWO FA