### PR TITLE
Add support for RegisterFunction

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,16 @@
                 "category": "%playfab-explorer.commands.playfab%"
             },
             {
+                "command": "playfabExplorer.registerFunction",
+                "title": "%playfab-explorer.commands.registerFunction%",
+                "category": "%playfab-explorer.commands.playfab%"
+            },
+            {
+                "command": "playfabExplorer.unregisterFunction",
+                "title": "%playfab-explorer.commands.unregisterFunction%",
+                "category": "%playfab-explorer.commands.playfab%"
+            },
+            {
                 "command": "playfabExplorer.getCloudScriptRevision",
                 "title": "%playfab-explorer.commands.getCloudScriptRevision%",
                 "category": "%playfab-explorer.commands.playfab%"
@@ -132,6 +142,14 @@
                 },
                 {
                     "command": "playfabExplorer.setTitleInternalData",
+                    "when": "view == playfabExplorer && viewItem == title"
+                },
+                {
+                    "command": "playfabExplorer.registerFunction",
+                    "when": "view == playfabExplorer && viewItem == title"
+                },
+                {
+                    "command": "playfabExplorer.unregisterFunction",
                     "when": "view == playfabExplorer && viewItem == title"
                 },
                 {

--- a/package.nls.json
+++ b/package.nls.json
@@ -25,6 +25,8 @@
     "playfab-explorer.commands.setTitleData": "Set title data",
     "playfab-explorer.commands.getTitleInternalData": "Get title internal data",
     "playfab-explorer.commands.setTitleInternalData": "Set title internal data",
+    "playfab-explorer.commands.registerFunction": "Register function",
+    "playfab-explorer.commands.unregisterFunction": "Unregister function",
     "playfab-explorer.commands.getCloudScriptRevision": "Get CloudScript revision",
     "playfab-explorer.commands.updateCloudScript": "Update CloudScript",
     "playfab-explorer.commands.createFunctionApp": "Create Function App",
@@ -42,5 +44,9 @@
     "playfab-explorer.keyValue": "Key Name",
     "playfab-explorer.keyPrompt": "Please enter the key name.",
     "playfab-explorer.valueValue": "Value",
-    "playfab-explorer.valuePrompt": "Please enter the value."
+    "playfab-explorer.valuePrompt": "Please enter the value.",
+    "playfab-explorer.functionNameValue": "Function Name",
+    "playfab-explorer.functionNamePrompt": "Please enter the name of the function.",
+    "playfab-explorer.functionUriValue": "Function URL",
+    "playfab-explorer.functionUriPrompt": "Please enter the URL of the function."
 }

--- a/src/helpers/PlayFabDataHelpers.ts
+++ b/src/helpers/PlayFabDataHelpers.ts
@@ -12,3 +12,20 @@ export function MapFromObject(obj: object): Map<string, string> {
     }
     return map;
 }
+
+
+export function GetLastPathPartFromUri(uri: string): string {
+    let uriSchemeHostAndPath: string = uri.split('?')[0];
+    let hostStartIndex: number = uriSchemeHostAndPath.indexOf("//") + 2;
+    let uriHostAndPath: string = uriSchemeHostAndPath.substring(hostStartIndex);
+    let pathStartIndex: number = uriHostAndPath.indexOf("/") + 1;
+    let uriPath: string = uriHostAndPath.substring(pathStartIndex);
+
+    let result: string = null;
+    if(uriPath !== uriHostAndPath){
+        let uriPathParts: string[] = uriPath.split('/');    
+        result =  uriPathParts[uriPathParts.length - 1];
+    }
+
+    return result === "" ? null : result;
+}

--- a/src/helpers/PlayFabUriConstants.ts
+++ b/src/helpers/PlayFabUriConstants.ts
@@ -4,12 +4,12 @@
 //---------------------------------------------------------------------------------------------
 
 export class PlayFabUriConstants {
-    private static adminBaseUrl: string = 'https://{titleId}.playfabapi.com'
+    private static playfabBaseUrl: string = 'https://{titleId}.playfabapi.com'
 
     public static editorBaseUrl: string = 'https://editor.playfabapi.com';
 
-    public static GetAdminBaseUrl(titleId: string): string {
-        return PlayFabUriConstants.adminBaseUrl.replace('{titleId}', titleId);
+    public static GetPlayFabBaseUrl(titleId: string): string {
+        return PlayFabUriConstants.playfabBaseUrl.replace('{titleId}', titleId);
     }
 
     public static createTitlePath: string = '/DeveloperTools/User/CreateTitle';
@@ -17,6 +17,8 @@ export class PlayFabUriConstants {
     public static setTitleDataPath: string = '/Admin/SetTitleData';
     public static getTitleInternalDataPath: string = '/Admin/GetTitleInternalData';
     public static setTitleInternalDataPath: string = '/Admin/SetTitleInternalData';
+    public static registerFunctionPath: string = '/CloudScript/RegisterFunction';
+    public static unregisterFunctionPath: string = '/CloudScript/UnregisterFunction';    
     public static updateCloudScriptPath: string = '/Admin/UpdateCloudScript';
     public static getCloudScriptRevisionPath: string = '/Admin/GetCloudScriptRevision';
 
@@ -25,4 +27,6 @@ export class PlayFabUriConstants {
     public static createAccountPath: string = '/DeveloperTools/User/RegisterAccount';
     public static loginPath: string = '/DeveloperTools/User/Login';
     public static logoutPath: string = '/DeveloperTools/User/Logout';
+
+    public static getEntityToken: string = '/Authentication/GetEntityToken';
 };

--- a/src/test/datahelper.test.ts
+++ b/src/test/datahelper.test.ts
@@ -3,8 +3,8 @@
 //  Licensed under the MIT License. See License.md in the project root for license information.
 //---------------------------------------------------------------------------------------------
 
-import * as assert from 'assert'
-import { MapFromObject } from '../helpers/PlayFabDataHelpers'
+import * as assert from 'assert';
+import { GetLastPathPartFromUri, MapFromObject } from '../helpers/PlayFabDataHelpers';
 
 suite('DataHelper Tests', function () {
 
@@ -47,4 +47,57 @@ suite('DataHelper Tests', function () {
         assert(map.size == 0, `Expected empty map, but map has ${map.size} entries.`);
     });
 
+    test('GetLastPathPartFromUriForEmptyStringReturnsNull', function() {
+        let result: string = GetLastPathPartFromUri("");
+        assert(result === null, `Expected empty string but got ${result}`);
+    });
+
+    test('GetLastPathPartFromUriForUriWithNoPathReturnsNull', function() {
+        let result: string = GetLastPathPartFromUri("http://www.microsoft.com");
+        assert(result === null, `Expected empty string but got ${result}`);
+    });
+
+    test('GetLastPathPartFromUriForUriWithNoSlashAtEndOfPathReturnsExpectedValue', function() {
+        let result: string = GetLastPathPartFromUri("http://www.microsoft.com/path1");
+        assert(result === "path1", `Expected path1 but got ${result}`);
+
+        result = GetLastPathPartFromUri("http://www.microsoft.com/path1/path2");
+        assert(result === "path2", `Expected path2 but got ${result}`)
+
+        result = GetLastPathPartFromUri("http://www.microsoft.com/path1/path2/path3");
+        assert(result === "path3", `Expected path3 but got ${result}`)
+    });
+
+    test('GetLastPathPartFromUriForUriWithNoSlashAtEndOfPathAndQueryStringReturnsExpectedValue', function() {
+        let result: string = GetLastPathPartFromUri("http://www.microsoft.com/path1?code=abc");
+        assert(result === "path1", `Expected path1 but got ${result}`);
+
+        result = GetLastPathPartFromUri("http://www.microsoft.com/path1/path2?code=abc");
+        assert(result === "path2", `Expected path2 but got ${result}`)
+
+        result = GetLastPathPartFromUri("http://www.microsoft.com/path1/path2/path3?code=abc");
+        assert(result === "path3", `Expected path3 but got ${result}`)
+    });
+
+    test('GetLastPathPartFromUriForUriWithSlashAtEndOfPathReturnsExpectedValue', function() {
+        let result: string = GetLastPathPartFromUri("http://www.microsoft.com/path1/");
+        assert(result === null, `Expected null string but got ${result}`);
+
+        result = GetLastPathPartFromUri("http://www.microsoft.com/path1/path2/");
+        assert(result === null, `Expected null string but got ${result}`)
+
+        result = GetLastPathPartFromUri("http://www.microsoft.com/path1/path2/path3/");
+        assert(result === null, `Expected null but got ${result}`)
+    });
+
+    test('GetLastPathPartFromUriForUriWithSlashAtEndOfPathAndQueryStringReturnsExpectedValue', function() {
+        let result: string = GetLastPathPartFromUri("http://www.microsoft.com/path1/?code=abc");
+        assert(result === null, `Expected null string but got ${result}`);
+
+        result = GetLastPathPartFromUri("http://www.microsoft.com/path1/path2/?code=abc");
+        assert(result === null, `Expected null string but got ${result}`)
+
+        result = GetLastPathPartFromUri("http://www.microsoft.com/path1/path2/path3/?code=abc");
+        assert(result === null, `Expected null but got ${result}`)
+    });
 });


### PR DESCRIPTION
This commit adds rudimentary support for registering an Azure function
with PlayFab for a given title, such that said function can then be
called by a game or, in future, in response to a playstram event.

Details

Add commands for registering and unregistering functions.
Add methods to the input gatherer for PlayFab Explorer to get input for
register and unregister function.

The register command makes an API call to convert the title secret into
an entity tokem and then calls the RegisterFunction API.

Add URI paths for RegisterFunction, UnregisterFunction and
GetEntityToken

Also rename GetAdminBaseUrl to GetPlayFabBaseUrl.

Add GetLastPathPartFromUri function which is used to 'suggest' a
function name as part of gathering input for the register call.

 GetLastPathPartFromUri returns the part of the URI after the last /
 character that occurs after the host name.

Add various tests for GetLastPathPartFromUri.

Add menu commands and NLS strings for RegisterFunction and
UnregisterFunction.