### PR TITLE
Make Open Game Manager Page explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "PlayFab Account",
     "description": "%playfab-account.description%",
     "license": "SEE LICENSE IN LICENSE.md",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "publisher": "ms-playfab",
     "icon": "resources/playfab.png",
     "repository": {
@@ -73,6 +73,11 @@
                 "command": "playfabExplorer.createTitle",
                 "title": "%playfab-explorer.commands.createTitle%",
                 "category": "%playfab-explorer.commands.playfab%"
+            },            
+            {
+                "command": "playfabExplorer.openGameManagerPageForTitle",
+                "title": "%playfab-explorer.commands.openGameManagerPageForTitle%",
+                "category": "%playfab-explorer.commands.playfab%"
             },
             {
                 "command": "playfabExplorer.getTitleData",
@@ -130,44 +135,49 @@
                     "group": "1@1"
                 },
                 {
-                    "command": "playfabExplorer.getTitleData",
+                    "command": "playfabExplorer.openGameManagerPageForTitle",
                     "when": "view == playfabExplorer && viewItem == title",
                     "group": "1@1"
                 },
                 {
-                    "command": "playfabExplorer.setTitleData",
-                    "when": "view == playfabExplorer && viewItem == title",
-                    "group": "1@2"
-                },
-                {
-                    "command": "playfabExplorer.getTitleInternalData",
-                    "when": "view == playfabExplorer && viewItem == title",
-                    "group": "1@3"
-                },
-                {
-                    "command": "playfabExplorer.setTitleInternalData",
-                    "when": "view == playfabExplorer && viewItem == title",
-                    "group": "1@4"
-                },
-                {
-                    "command": "playfabExplorer.registerFunction",
+                    "command": "playfabExplorer.getTitleData",
                     "when": "view == playfabExplorer && viewItem == title",
                     "group": "2@1"
                 },
                 {
-                    "command": "playfabExplorer.unregisterFunction",
+                    "command": "playfabExplorer.setTitleData",
                     "when": "view == playfabExplorer && viewItem == title",
                     "group": "2@2"
                 },
                 {
-                    "command": "playfabExplorer.getCloudScriptRevision",
+                    "command": "playfabExplorer.getTitleInternalData",
+                    "when": "view == playfabExplorer && viewItem == title",
+                    "group": "2@3"
+                },
+                {
+                    "command": "playfabExplorer.setTitleInternalData",
+                    "when": "view == playfabExplorer && viewItem == title",
+                    "group": "2@4"
+                },
+                {
+                    "command": "playfabExplorer.registerFunction",
                     "when": "view == playfabExplorer && viewItem == title",
                     "group": "3@1"
                 },
                 {
-                    "command": "playfabExplorer.updateCloudScript",
+                    "command": "playfabExplorer.unregisterFunction",
                     "when": "view == playfabExplorer && viewItem == title",
                     "group": "3@2"
+                },
+                {
+                    "command": "playfabExplorer.getCloudScriptRevision",
+                    "when": "view == playfabExplorer && viewItem == title",
+                    "group": "4@1"
+                },
+                {
+                    "command": "playfabExplorer.updateCloudScript",
+                    "when": "view == playfabExplorer && viewItem == title",
+                    "group": "4@2"
                 }
             ]
         },

--- a/src/playfab-explorer.ts
+++ b/src/playfab-explorer.ts
@@ -234,7 +234,7 @@ export class PlayFabExplorer {
         context.subscriptions.push(commands.registerCommand('playfabExplorer.registerFunction', async (title) => await this.registerFunction(title.data)));
         context.subscriptions.push(commands.registerCommand('playfabExplorer.unregisterFunction', async (title) => await this.unregisterFunction(title.data)));
         context.subscriptions.push(commands.registerCommand('playfabExplorer.openGameManagerPageForTitle',
-            (titleId: string) => commands.executeCommand('vscode.open', Uri.parse(`https://developer.playfab.com/en-US/${titleId}/dashboard`))));
+            (title) => commands.executeCommand('vscode.open', Uri.parse(`https://developer.playfab.com/en-US/${title.data.Id}/dashboard`))));
     }
 
     private async getUserInputForCreateTitle(): Promise<CreateTitleRequest> {
@@ -490,11 +490,8 @@ export class PlayFabStudioTreeProvider implements TreeDataProvider<IEntry> {
     }
 
     private getTitleTreeItem(entry: IEntry): TreeItem {
-        let title: Title = entry.data;
-        const menuTitle = localize('playfab-explorer.commands.openGameManagerPageForTitle', 'Open in Game Manager');
         const treeItem = new TreeItem(entry.name, TreeItemCollapsibleState.None);
         treeItem.contextValue = 'title';
-        treeItem.command = { command: 'playfabExplorer.openGameManagerPageForTitle', title: menuTitle, arguments: [title.Id] };
         return treeItem;
     }
 


### PR DESCRIPTION
Make opening the game manager page for a title an explicit manu command
rather than having it occur whenever the title tree item is selected.

Re-number menu groups to accomodate new menu.