### PR TITLE
Support sorting in tree view

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ The PlayFab Account extension provides a single PlayFab sign-in experience for a
 
 ## Commands
 
-
 | Command |  |
 | --- | --- |
 | `PlayFab: Sign In`  | Sign in to your PlayFab account.
@@ -15,7 +14,9 @@ The PlayFab Account extension provides a single PlayFab sign-in experience for a
 
 | Name | Description | Default |
 | --- | --- | --- |
-| playfab.showSignedInEmail | Whether to show the email address (e.g., in the status bar) of the signed in account.	 | true
+| playfab.showSignedInEmail | Whether to show the email address (e.g., in the status bar) of the signed in account. | true
+| playfab.sortStudiosAlphabetically | Whether to sort studios alphabetically in the tree view. | true
+| playfab.sortTitlesAlphabetically | Whether to sort titles alphabetically in the tree view. | true
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -190,6 +190,16 @@
                         "type": "boolean",
                         "default": true,
                         "description": "%playfab-account.configuration.showSignedInEmail.description%"
+                    },
+                    "playfab.sortStudiosAlphabetically": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "%playfab-account.configuration.sortStudiosAlphabetically.description%"
+                    },
+                    "playfab.sortTitlesAlphabetically": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "%playfab-account.configuration.sortTitlesAlphabetically.description%"
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -19,6 +19,8 @@
     "playfab-account.passwordPrompt": "Please enter your password.",
     "playfab-account.twofaPrompt": "Please enter your two-factor auth code.",
     "playfab-account.configuration.showSignedInEmail.description": "Whether to show the email address (e.g., in the status bar) of the signed in account.",
+    "playfab-account.configuration.sortStudiosAlphabetically.description": "Whether to sort studios alphabetically in the tree.",
+    "playfab-account.configuration.sortTitlesAlphabetically.description": "Whether to sort titles alphabetically in the tree.",
     "playfab-explorer.commands.playfab": "PlayFab Explorer",
     "playfab-explorer.commands.createTitle": "Create a title",
     "playfab-explorer.commands.getTitleData": "Get title data",


### PR DESCRIPTION
This PR adds support for sorting both Studios and Titles alphabetically
in the tree view. Each type can be sorted or not independant of the
other. Sorting is controlled via settings.

Details

Add static sort functions to PlayFabStudioTreeProvider for sorting
Studios and Titles. Both call a helper function that sorts strings.

Register for configuration changed events and call
PlayFabStudioTreeProvider.refresh when configuration changes.

Call appropriate sort functions when returning data for the tree view.

Add settings for both studio and title order to package.json and
corresponding strings to package.nls.json

Update README.md with new settings descriptions.