### PR TITLE
Rename as PlayFab change_to_playfab_explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# PlayFab Account and Sign-In
-The PlayFab Account extension provides a single PlayFab sign-in experience for all other PlayFab extensions. 
+# PlayFab Explorer
+The PlayFab Explorer extension provides a single PlayFab sign-in experience and tree view for all other PlayFab extensions. 
 
 ## Commands
 
@@ -8,7 +8,7 @@ The PlayFab Account extension provides a single PlayFab sign-in experience for a
 | `PlayFab: Sign In`  | Sign in to your PlayFab account.
 | `PlayFab: Sign Out` | Sign out of your PlayFab account.
 | `PlayFab: Create an Account`  | If you don't have an PlayFab Account, you can [sign up](https://developer.playfab.com/en-US/sign-up) for one today.
-<sup>1</sup> On Windows: Requires Node.js 6 or later to be installed (https://nodejs.org).
+| `PlayFab: Create title`  | Create a new title.
 
 ## Settings
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-	"name": "playfab-account",
-	"version": "0.0.1",
+	"name": "playfab-explorer",
+	"version": "0.0.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "playfab-account",
-    "displayName": "PlayFab Account",
-    "description": "%playfab-account.description%",
+    "name": "playfab-explorer",
+    "displayName": "PlayFab Explorer",
+    "description": "%playfab-explorer.description%",
     "license": "SEE LICENSE IN LICENSE.md",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "publisher": "ms-playfab",
     "icon": "resources/playfab.png",
     "repository": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,5 @@
 {
-    "playfab-account.description": "A common PlayFab Sign-In extension for VS Code.",
+    "playfab-explorer.description": "A common PlayFab Explorer extension for VS Code.",
     "playfab-account.commands.playfab": "PlayFab Account",
     "playfab-account.commands.login": "Sign In",
     "playfab-account.commands.loginTitle": "Sign In to PlayFab...",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,8 +12,8 @@ import { PlayFabExplorer } from './playfab-explorer';
 const localize = loadMessageBundle();
 
 export class ExtensionInfo {
-    private static extensionName: string = 'vscode-playfab-account';
-    private static extensionVersion: string = '0.0.1';
+    private static extensionName: string = 'vscode-playfab-explorer';
+    private static extensionVersion: string = '0.0.4';
 
     public static getExtensionInfo(): string { return ExtensionInfo.extensionName + '_' + ExtensionInfo.extensionVersion };
     public static getExtensionName(): string { return ExtensionInfo.extensionName; }


### PR DESCRIPTION
Rename the extension to vscode-playfab-explorer

Details

Update readme.md to reflect new name.

Update nls strings to reflect new name.

Update version to 0.0.4