### PR TITLE
Remove TriggerType and InvocationSource

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -51,8 +51,6 @@
     "playfab-explorer.keyPrompt": "Please enter the key name.",
     "playfab-explorer.valueValue": "Value",
     "playfab-explorer.valuePrompt": "Please enter the value.",
-    "playfab-explorer.triggerTypePrompt": "Please choose a trigger type.",
-    "playfab-explorer.invocationSourcePrompt": "Please choose an invocation source.",
     "playfab-explorer.functionNameValue": "Function Name",
     "playfab-explorer.functionNamePrompt": "Please enter the name of the function.",
     "playfab-explorer.functionUriValue": "Function URL",

--- a/src/models/PlayFabCloudScriptModels.ts
+++ b/src/models/PlayFabCloudScriptModels.ts
@@ -6,13 +6,9 @@
 export class FunctionInfo {
     FunctionName: string;
     FunctionUrl: string;
-    TriggerType: string;
-    InvocationSource: string;
 }
 
 export class ListFunctionsRequest {
-    TriggerType: string;
-    InvocationSource: string;
 }
 
 export class ListFunctionsResponse {
@@ -25,7 +21,6 @@ export class RegisterFunctionRequest {
 }
 
 export class RegisterFunctionResponse {
-
 }
 
 export class UnregisterFunctionRequest {
@@ -33,5 +28,4 @@ export class UnregisterFunctionRequest {
 }
 
 export class UnregisterFunctionResponse {
-    
 }

--- a/src/playfab-explorer.ts
+++ b/src/playfab-explorer.ts
@@ -343,13 +343,13 @@ export class PlayFabExplorer {
         let newline: string = process.platform == 'win32' ? '\r\n' : '\n';
         let result: string = "# List Of Functions";
         result += newline;
-        result += "| Name | Url | Trigger | Invocation |";
+        result += "| Name | Url |";
         result += newline;
-        result += "| --- | --- | --- | --- |";
+        result += "| --- | --- |";
         result += newline;
 
         functions.forEach((fnInfo: FunctionInfo) => {
-            result += `| ${fnInfo.FunctionName} | ${fnInfo.FunctionUrl} | ${fnInfo.TriggerType} | ${fnInfo.InvocationSource} |`;
+            result += `| ${fnInfo.FunctionName} | ${fnInfo.FunctionUrl} |`;
             result += newline;
         });
 
@@ -508,19 +508,7 @@ class PlayFabExplorerUserInputGatherer implements IPlayFabExplorerInputGatherer 
     }
 
     public async getUserInputForListFunctions(): Promise<ListFunctionsRequest> {
-        const triggerTypePrompt: string = localize('playfab-explorer.triggerTypePrompt', 'Please choose a trigger type.');
-        const invocationSourcePrompt: string = localize('playfab-explorer.invocationSourcePrompt', 'Please choose an invocation source.');
-
-        const triggerType: string = await window.showQuickPick(["All", "Http", "Azure Queue"], { placeHolder: triggerTypePrompt });
-        let invocationSource: string = "";
-
-        if (triggerType !== "http") {
-            invocationSource = await window.showQuickPick(["All", "PlayStream", "Segment", "Scheduled Task"], { placeHolder: invocationSourcePrompt });
-        }
-
         let request: ListFunctionsRequest = {
-            TriggerType: triggerType,
-            InvocationSource: invocationSource
         };
 
         return request;

--- a/src/test/explorer.test.ts
+++ b/src/test/explorer.test.ts
@@ -80,8 +80,6 @@ suite('Explorer Tests', function () {
     .returns(async () => {
       listFunctionsInputCount++;
       let result: ListFunctionsRequest = {
-        TriggerType: "Http",
-        InvocationSource: "Http"
       };
       return result;
     });
@@ -336,15 +334,11 @@ suite('Explorer Tests', function () {
           Functions: [
             {
               FunctionName: "Fn1",
-              FunctionUrl: "https://some.func",
-              TriggerType: "Http",
-              InvocationSource: "Http"
+              FunctionUrl: "https://some.func"
             },
             {
               FunctionName: "Fn2",
-              FunctionUrl: "https://someother.func",
-              TriggerType: "Http",
-              InvocationSource: "Http"
+              FunctionUrl: "https://someother.func"
             },
           ]
         };


### PR DESCRIPTION
This PR removes TriggerType and InvocationSource from RegisterFunction
and ListFunctions API calls and assoicated machinery. We will add
TriggerType back once we support multiple Azure Function trigger types
in MainServer.

Details

Remove prompt strings for trigger type and invocation source from
package.nls.json.

Remove TriggerType and InvocationSource fields from models in
PlayFabCloudScriptModels.cs.

Remove TriggerType and Invocation columns from markdown generated from
the result of the ListFunctions API.

Remove user prompts from the getUserInputForListFunctions method in
PlayFabExplorer.

Remove TriggerType and InvocationSource from various tests.