### PR TITLE
Add title id support

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,6 +261,11 @@
                         "type": "string",
                         "default": "",
                         "description": "%playfab-account.configuration.cloudName.description%"
+                    },
+                    "playfab.showTitleIds": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "%playfab-account.configuration.showTitleIds.description%"
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -24,6 +24,7 @@
     "playfab-account.configuration.loginId.description": "PlayFab Login Id.",
     "playfab-account.configuration.jsonSpaces.description": "Number of spaces to use when displaying JSON data.",
     "playfab-account.configuration.cloudName.description": "Name of a private cloud.",
+    "playfab-account.configuration.showTitleIds.description": "Whether to show title ids in the tree.",
     "playfab-explorer.commands.playfab": "PlayFab Explorer",
     "playfab-explorer.commands.createTitle": "Create a title",
     "playfab-explorer.commands.getTitleData": "Get title data",

--- a/src/playfab-treeprovider.ts
+++ b/src/playfab-treeprovider.ts
@@ -188,9 +188,11 @@ export class PlayFabStudioTreeProvider implements TreeDataProvider<ITreeNode> {
             titles = studio.Titles.sort(PlayFabStudioTreeProvider.sortTitlesByName);
         }
 
+        let showTitleIds: boolean = this.getConfigValue('showTitleIds');
+
         return titles.map((title: Title) => {
             let result = new TreeNode();
-            result.name = title.Name;
+            result.name = showTitleIds ? `${title.Name} (${title.Id})` : title.Name;
             result.type = 'Title';
             result.data = title;
             return result;


### PR DESCRIPTION
This PR adds support for showing title ids in the PlayFab Explorer tree
view. This behaviour is controlled by a setting; showTitleIds.