### PR TITLE
Sign-out on cloud change

### DIFF
--- a/src/playfab-account.api.d.ts
+++ b/src/playfab-account.api.d.ts
@@ -17,7 +17,6 @@ export interface IPlayFabAccount {
 }
 
 export interface IPlayFabSession {
-    readonly cloud: string;
     readonly userId: string;
     readonly credentials: IPlayFabCredentials;
 }

--- a/src/playfab-account.ts
+++ b/src/playfab-account.ts
@@ -65,7 +65,6 @@ export class PlayFabLoginManager {
             request,
             (response: CreateAccountResponse): void => {
                 this.api.sessions.splice(0, this.api.sessions.length, {
-                    cloud: 'global',
                     credentials: {
                         token: response.DeveloperClientToken
                     },
@@ -97,7 +96,6 @@ export class PlayFabLoginManager {
             request,
             (response: LoginResponse): void => {
                 this.api.sessions.splice(0, this.api.sessions.length, {
-                    cloud: 'global',
                     credentials: {
                         token: response.DeveloperClientToken
                     },
@@ -123,7 +121,6 @@ export class PlayFabLoginManager {
                 request,
                 (response: LoginResponse): void => {
                     this.api.sessions.splice(0, this.api.sessions.length, {
-                        cloud: 'global',
                         credentials: {
                             token: response.DeveloperClientToken
                         },


### PR DESCRIPTION
If the user changes the cloud setting, then if the user is signed in, we
need to sign them out of the previous cloud.

Details

Add code to updateCloud to check if the cloud is actually changing. If
it is, then check to see if we are signed in by checking for a session
count that is greater than zero. If we are signed in, run the sign-out
command. In either case, store the new cloud value. NOTE: We sign-out
*before* storing the new cloud value because the cloud value affects the
base URI for API calls.

Remove the cloud property from IPlayFabSession as it was not used.