### PR TITLE
Update description in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "playfab-explorer",
     "displayName": "PlayFab Explorer",
-    "description": "%playfab-explorer.description%",
+    "description": "A common PlayFab Explorer extension for VS Code.",
     "license": "SEE LICENSE IN LICENSE.md",
     "version": "0.1.0",
     "publisher": "Playfab",


### PR DESCRIPTION
Apparently package.json doesn't expand the description defined in
package.nls.json, so putting the verbatim text in package.json instead.