### PR TITLE
Address security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -789,7 +789,7 @@
 				"infer-owner": "^1.0.3",
 				"lru-cache": "^5.1.1",
 				"mississippi": "^3.0.0",
-				"mkdirp": "^0.5.4",
+				"mkdirp": "^0.5.1",
 				"move-concurrently": "^1.0.1",
 				"promise-inflight": "^1.0.1",
 				"rimraf": "^2.6.3",
@@ -1082,7 +1082,7 @@
 				"aproba": "^1.1.1",
 				"fs-write-stream-atomic": "^1.0.8",
 				"iferr": "^0.1.5",
-				"mkdirp": "^0.5.4",
+				"mkdirp": "^0.5.1",
 				"rimraf": "^2.5.4",
 				"run-queue": "^1.0.0"
 			}
@@ -1870,8 +1870,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1892,14 +1891,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1914,20 +1911,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2044,8 +2038,7 @@
 				"inherits": {
 					"version": "2.0.4",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2057,7 +2050,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2072,22 +2064,18 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "1.2.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true
+					"bundled": true
 				},
 				"minipass": {
 					"version": "2.9.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -2105,8 +2093,6 @@
 				"mkdirp": {
 					"version": "0.5.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "^1.2.5"
 					}
@@ -2135,7 +2121,7 @@
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.4",
+						"mkdirp": "^0.5.1",
 						"needle": "^2.2.1",
 						"nopt": "^4.0.1",
 						"npm-packlist": "^1.1.6",
@@ -2144,6 +2130,18 @@
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
 						"tar": "^4.4.2"
+					},
+					"dependencies": {
+						"mkdirp": {
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimist": "^1.2.5"
+							}
+						}
 					}
 				},
 				"nopt": {
@@ -2168,8 +2166,7 @@
 				"npm-normalize-package-bin": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"npm-packlist": {
 					"version": "1.4.8",
@@ -2197,8 +2194,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2210,7 +2206,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2288,8 +2283,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2325,7 +2319,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2345,7 +2338,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2366,9 +2358,21 @@
 						"fs-minipass": "^1.2.5",
 						"minipass": "^2.8.6",
 						"minizlib": "^1.2.1",
-						"mkdirp": "^0.5.4",
+						"mkdirp": "^0.5.0",
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.3"
+					},
+					"dependencies": {
+						"mkdirp": {
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimist": "^1.2.5"
+							}
+						}
 					}
 				},
 				"util-deprecate": {
@@ -2389,14 +2393,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -3019,9 +3021,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 		},
 		"lru-cache": {
 			"version": "5.1.1",
@@ -3163,7 +3165,8 @@
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"dev": true
 		},
 		"mississippi": {
 			"version": "3.0.0",
@@ -3208,6 +3211,7 @@
 			"version": "0.5.4",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
 			"integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -3227,7 +3231,7 @@
 				"growl": "1.10.5",
 				"he": "1.1.1",
 				"minimatch": "3.0.4",
-				"mkdirp": "0.5.4",
+				"mkdirp": "0.5.1",
 				"supports-color": "5.4.0"
 			},
 			"dependencies": {
@@ -3252,18 +3256,18 @@
 					}
 				},
 				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true
 				},
 				"mkdirp": {
-					"version": "0.5.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
-					"integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
 					"requires": {
-						"minimist": "^1.2.5"
+						"minimist": "0.0.8"
 					}
 				},
 				"supports-color": {
@@ -3286,7 +3290,7 @@
 				"aproba": "^1.1.1",
 				"copy-concurrently": "^1.0.0",
 				"fs-write-stream-atomic": "^1.0.8",
-				"mkdirp": "^0.5.4",
+				"mkdirp": "^0.5.1",
 				"rimraf": "^2.5.4",
 				"run-queue": "^1.0.3"
 			}
@@ -4659,7 +4663,7 @@
 				"glob": "^7.1.1",
 				"js-yaml": "^3.13.1",
 				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.4",
+				"mkdirp": "^0.5.1",
 				"resolve": "^1.3.2",
 				"semver": "^5.3.0",
 				"tslib": "^1.8.0",
@@ -4990,7 +4994,7 @@
 				"loader-utils": "^1.2.3",
 				"memory-fs": "^0.4.1",
 				"micromatch": "^3.1.10",
-				"mkdirp": "^0.5.4",
+				"mkdirp": "^0.5.3",
 				"neo-async": "^2.6.1",
 				"node-libs-browser": "^2.2.1",
 				"schema-utils": "^1.0.0",
@@ -5270,9 +5274,9 @@
 			}
 		},
 		"yargs-parser": {
-			"version": "13.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-			"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+			"version": "13.1.2",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+			"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^5.0.0",


### PR DESCRIPTION
Update yargs-parser and lodash to newer packages to address security
vulnerabilities by running npm audit fix.