### PR TITLE
Remove large png files from package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,8 @@
 .vscode
 node_modules
 out/
+resources/CommandTreeView.png
+resources/SignIn.png
 src/
 tsconfig.json
 webpack.config.js

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "engines": {
         "vscode": "^1.30.0"
     },
-    "homepage": "https://github.com/Microsoft/vscode-playfab-explorer/blob/master/README.md",
+    "homepage": "https://github.com/PlayFab/vscode-playfab-explorer/blob/master/README.md",
     "categories": [
         "Other"
     ],


### PR DESCRIPTION
Exclude PNGs that are displayed as part of README.MD from the generated
package.
Fix README.MD link in package.json