### PR TITLE
Address security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -798,6 +798,15 @@
 				"unset-value": "^1.0.0"
 			}
 		},
+		"call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
+			}
+		},
 		"camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -2431,14 +2440,23 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
+		},
+		"get-intrinsic": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
 		},
 		"get-stream": {
 			"version": "4.1.0",
@@ -2541,7 +2559,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -2555,8 +2572,7 @@
 		"has-symbols": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-			"dev": true
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -3066,9 +3082,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.20",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
 		"log-symbols": {
@@ -3981,6 +3997,14 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
+		"qs": {
+			"version": "6.10.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+			"integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+			"requires": {
+				"side-channel": "^1.0.4"
+			}
+		},
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -4379,6 +4403,23 @@
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
 		},
+		"side-channel": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"requires": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			},
+			"dependencies": {
+				"object-inspect": {
+					"version": "1.10.2",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+					"integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
+				}
+			}
+		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -4564,9 +4605,9 @@
 			"dev": true
 		},
 		"ssri": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+			"integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
 			"dev": true,
 			"requires": {
 				"figgy-pudding": "^3.5.1"
@@ -4882,30 +4923,18 @@
 			"dev": true
 		},
 		"tunnel": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-			"integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
 		},
 		"typed-rest-client": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.7.1.tgz",
-			"integrity": "sha512-fZRDWFtUp3J2E0jOiCJYZ9LDrYZHpjY95su//ekqXERS7C1qojP6movh7M4JGURJnBuTVsO0g2N4vEoW5o3Djw==",
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
+			"integrity": "sha512-MyfKKYzk3I6/QQp6e1T50py4qg+c+9BzOEl2rBmQIpStwNUoqQ73An+Tkfy9YuV7O+o2mpVVJpe+fH//POZkbg==",
 			"requires": {
 				"qs": "^6.9.1",
-				"tunnel": "0.0.4",
-				"underscore": "1.8.3"
-			},
-			"dependencies": {
-				"qs": {
-					"version": "6.9.1",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-					"integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
-				},
-				"underscore": {
-					"version": "1.8.3",
-					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-				}
+				"tunnel": "0.0.6",
+				"underscore": "^1.12.1"
 			}
 		},
 		"typedarray": {
@@ -4932,10 +4961,9 @@
 			"dev": true
 		},
 		"underscore": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-			"integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==",
-			"dev": true
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+			"integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
 		},
 		"union-value": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -319,13 +319,13 @@
         "tslint": "^5.20.1",
         "typemoq": "^2.1.0",
         "typescript": "^2.6.1",
-        "underscore": "^1.9.2",
+        "underscore": "^1.13.1",
         "vscode-test": "^1.4.0",
         "webpack": "^4.42.1",
         "webpack-cli": "^3.3.10"
     },
     "dependencies": {
-        "typed-rest-client": "^1.7.1",
+        "typed-rest-client": "^1.8.4",
         "vscode-nls": "4.0.0"
     }
 }


### PR DESCRIPTION
npm audit reports 4 security vulnerabilities;

  High            Arbitrary Code Execution
  Package         underscore
  Dependency of   typed-rest-client
  More info       https://npmjs.com/advisories/1674

  Moderate        Regular Expression Denial of Service
  Package         ssri
  Dependency of   webpack [dev]
  More info       https://npmjs.com/advisories/565

  High            Command Injection
  Package         lodash
  Dependency of   typemoq [dev]
  More info       https://npmjs.com/advisories/1673

  High            Arbitrary Code Execution
  Package         underscore
  Dependency of   underscore [dev]
  More info       https://npmjs.com/advisories/1674

This PR is the result of running npm audit fix. It updates
typed-rest-client to version 1.8.4 and underscore to version 1.13.1 in
package.json and makes corresponding and additional changes to
package-lock.json