### PR TITLE
Update marketplace SVG URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Version](https://vsmarketplacebadge.apphb.com/version/playfab.playfab-explorer.svg)](https://marketplace.visualstudio.com/items?itemName=PlayFab.playfab-explorer) [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/PlayFab.playfab-explorer.svg)](https://marketplace.visualstudio.com/items?itemName=PlayFab.playfab-explorer)
+[![Version](https://img.shields.io/visual-studio-marketplace/v/playfab.playfab-explorer.svg)](https://marketplace.visualstudio.com/items?itemName=PlayFab.playfab-explorer) [![Installs](https://img.shields.io/visual-studio-marketplace/i/playfab.playfab-explorer.svg)](https://marketplace.visualstudio.com/items?itemName=PlayFab.playfab-explorer)
 
 # PlayFab Explorer
 The PlayFab Explorer extension provides a single PlayFab sign-in experience and tree view for all other PlayFab extensions, as well as some base functionality around titles and CloudScript.


### PR DESCRIPTION
The marketplace URL locations have changed from being hosted at vsmarketplacebadge.apphb.com to being hosted at
img.shields.io and the path format has also changed. This PR updates the URLs in README.md to reflect the new locations.