### PR TITLE
Exclude more files from VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,8 +1,9 @@
+.github/
+.gitignore
 .vscode
-node_modules
+node_modules/
 out/
 resources/CommandTreeView.png
 resources/SignIn.png
 src/
 tsconfig.json
-webpack.config.js


### PR DESCRIPTION
Exclude the content of the .github folder.
Exclude the .gitignore file.

Remove webpack.config.js as webpack automatically suppresses that file.